### PR TITLE
SnowflakeTimestampGenerator return 타입 string으로 변경

### DIFF
--- a/src/main/kotlin/com/moflow/urlshortener/service/SnowflakeTimestampGenerator.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/service/SnowflakeTimestampGenerator.kt
@@ -6,10 +6,10 @@ import java.time.Instant
 @Component
 class SnowflakeTimestampGenerator {
 
-    fun currentTimestamp(): Long {
+    fun currentTimestamp(): String {
         val bitOperand = ((1L shl TIMESTAMP_BITS) - 1)
         val timeMillis = Instant.now().toEpochMilli()
-        return (timeMillis - EPOCH) and bitOperand //and 연산자를 통해 필요한 41비트만 사용
+        return ((timeMillis - EPOCH) and bitOperand).toString() //and 연산자를 통해 필요한 41비트만 사용
     }
 
     companion object {

--- a/src/test/kotlin/com/moflow/urlshortener/service/SnowflakeTimestampGeneratorTest.kt
+++ b/src/test/kotlin/com/moflow/urlshortener/service/SnowflakeTimestampGeneratorTest.kt
@@ -25,7 +25,7 @@ class SnowflakeTimestampGeneratorTest {
         mockkStatic(Instant::class)
         every { Instant.now() } returns instant
 
-        val expected = (currentMillis - epoch) and ((1L shl timestampBits) - 1)
+        val expected = ((currentMillis - epoch) and ((1L shl timestampBits) - 1)).toString()
 
         // Act
         val actual = sut.currentTimestamp()


### PR DESCRIPTION
* 식별자 용도로 41비트를 표현할 때 Long보다는 String이 더 낫다고 판단

close: #23