### PR TITLE
Url mapping 할 때 lock을 사용해서 등록한다

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,8 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("com.h2database:h2:2.2.224") // docker로 mysql 띄우기 전 임시 db
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("org.redisson:redisson-spring-boot-starter:3.23.5")
+
 	kapt("com.querydsl:querydsl-apt:5.0.0:jakarta")
 
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,11 @@ dependencies {
 	testImplementation("com.ninja-squad:springmockk:4.0.2")
 	testImplementation("io.mockk:mockk:1.13.2")
 	testRuntimeOnly("com.h2database:h2")
+	testImplementation("it.ozimov:embedded-redis:0.7.3") {
+		exclude("org.slf4j", "slf4j-simple")
+	}
 }
+
 jacoco {
 	toolVersion = "0.8.11"
 }

--- a/src/main/kotlin/com/moflow/urlshortener/domain/ShortUrl.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/domain/ShortUrl.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Id
 
 @Entity(name = "shorten_url")
 class ShortUrl(
+    @Column(unique = true)
     val originUrl: String,
     @Column(unique = true)
     val shortKey: String,

--- a/src/main/kotlin/com/moflow/urlshortener/lock/CustomSpringELParser.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/lock/CustomSpringELParser.kt
@@ -1,0 +1,16 @@
+package com.moflow.urlshortener.lock
+
+import org.springframework.expression.ExpressionParser
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+
+object CustomSpringELParser {
+    fun getDynamicValue(parameterNames: Array<String>, args: Array<Any>, key: String): Any {
+        val parser: ExpressionParser = SpelExpressionParser()
+        val context = StandardEvaluationContext()
+
+        parameterNames.indices.forEach { context.setVariable(parameterNames[it], args[it]) }
+
+        return parser.parseExpression(key).getValue(context, Any::class.java)!!
+    }
+}

--- a/src/main/kotlin/com/moflow/urlshortener/lock/DistributedLock.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/lock/DistributedLock.kt
@@ -1,0 +1,33 @@
+package com.moflow.urlshortener.lock
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * 분산 잠금을 위한 어노테이션.
+ * 해당 어노테이션을 메서드에 적용하면 해당 메서드 실행 시 분산 잠금이 적용된다.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class DistributedLock(
+    /**
+     * 잠금 키를 지정한다. Spring EL 표현식을 사용하여 동적인 값을 지정한다.
+     * 예: "#paramName"
+     * @return 잠금 키 문자열
+     */
+    val key: String = "",
+
+    /**
+     * 잠금을 획득하기 위해 대기할 최대 시간(초)을 지정.
+     */
+    val waitTime: Long = 5L,
+
+    /**
+     * 잠금을 보유할 최대 시간(초)을 지정.
+     */
+    val leaseTime: Long = 2L,
+
+    /**
+     * 잠금 시간을 나타내는 TimeUnit 설정
+     */
+    val timeUnit: TimeUnit = TimeUnit.SECONDS
+)

--- a/src/main/kotlin/com/moflow/urlshortener/lock/DistributedLockAop.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/lock/DistributedLockAop.kt
@@ -1,0 +1,50 @@
+package com.moflow.urlshortener.lock
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.redisson.api.RLock
+import org.redisson.api.RedissonClient
+import org.springframework.stereotype.Component
+
+@Aspect
+@Component
+class DistributedLockAop(
+    private val redissonClient: RedissonClient,
+) {
+    private val logger = KotlinLogging.logger { }
+
+    @Around("@annotation(com.moflow.urlshortener.lock.DistributedLock)")
+    fun lock(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+        val distributedLock = method.getAnnotation(DistributedLock::class.java)
+        val distributedLockKey = CustomSpringELParser.getDynamicValue(
+            signature.parameterNames,
+            joinPoint.args,
+            distributedLock.key
+        )
+        val key = "$REDISSON_LOCK_PREFIX${method.name}-$distributedLockKey"
+        val lock: RLock = redissonClient.getLock(key)
+
+        return try {
+            if (!lock.tryLock(distributedLock.waitTime, distributedLock.leaseTime, distributedLock.timeUnit)) {
+                logger.warn { "Failed to acquire lock -$key" }
+                return null
+            }
+            logger.debug { "lock key: $key" }
+            joinPoint.proceed()
+        } finally {
+            if (lock.isLocked && lock.isHeldByCurrentThread) {
+                lock.unlock()
+                logger.debug { "unlock key: $key" }
+            }
+        }
+    }
+
+    companion object {
+        private const val REDISSON_LOCK_PREFIX = "lock:"
+    }
+}

--- a/src/main/kotlin/com/moflow/urlshortener/service/ShortUrlMappingService.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/service/ShortUrlMappingService.kt
@@ -3,9 +3,11 @@ package com.moflow.urlshortener.service
 import com.moflow.urlshortener.domain.ShortUrl
 import com.moflow.urlshortener.dto.ShortUrlDto
 import com.moflow.urlshortener.extension.ShortUrlExtension.toShortUrlDto
+import com.moflow.urlshortener.lock.DistributedLock
 import com.moflow.urlshortener.repository.ShortUrlRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
 
 @Service
 @Transactional
@@ -14,6 +16,7 @@ class ShortUrlMappingService(
     private val shortUrlKeyGenerator: ShortUrlKeyGenerator,
     private val shortUrlRepository: ShortUrlRepository,
 ) {
+    @DistributedLock(key = "#originUrl", waitTime = 10L, leaseTime = 2L, timeUnit = TimeUnit.SECONDS)
     fun mapShortUrl(originUrl: String): ShortUrlDto {
         val existsShortUrl = shortUrlFindService.findByOriginUrl(originUrl)
         if (existsShortUrl != null) {

--- a/src/test/kotlin/com/moflow/urlshortener/UrlShortenerApplicationTests.kt
+++ b/src/test/kotlin/com/moflow/urlshortener/UrlShortenerApplicationTests.kt
@@ -1,13 +1,18 @@
 package com.moflow.urlshortener
 
+ import com.moflow.urlshortener.config.EmbeddedRedisConfig
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
 
+@ActiveProfiles("test")
 @SpringBootTest
+@Import(EmbeddedRedisConfig::class)
 class UrlShortenerApplicationTests {
 
-	@Test
-	fun contextLoads() {
-	}
+    @Test
+    fun contextLoads() {
+    }
 
 }

--- a/src/test/kotlin/com/moflow/urlshortener/config/EmbeddedRedisConfig.kt
+++ b/src/test/kotlin/com/moflow/urlshortener/config/EmbeddedRedisConfig.kt
@@ -1,0 +1,43 @@
+package com.moflow.urlshortener.config
+
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.redisson.spring.data.connection.RedissonConnectionFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import redis.embedded.RedisServer
+
+@TestConfiguration
+class EmbeddedRedisConfig(
+    @Value("\${spring.data.redis.host:localhost}")
+    private val redisHost: String,
+    @Value("\${spring.data.redis.port}")
+    private val redisPort: Int
+) {
+    private val redisServer = RedisServer(redisPort)
+
+    @PostConstruct
+    fun startRedisServer() {
+        redisServer.start()
+    }
+
+    @PreDestroy
+    fun stopRedisServer() {
+        redisServer.stop()
+    }
+
+    @Bean
+    fun redissonConnectionFactory() = RedissonConnectionFactory(redissonClient())
+
+    @Bean
+    fun redissonClient(): RedissonClient {
+        val config = Config();
+        config.useSingleServer()
+            .setAddress("redis://$redisHost:$redisPort")
+        return Redisson.create(config);
+    }
+}

--- a/src/test/kotlin/com/moflow/urlshortener/lock/CustomSpringELParserTest.kt
+++ b/src/test/kotlin/com/moflow/urlshortener/lock/CustomSpringELParserTest.kt
@@ -1,0 +1,23 @@
+package com.moflow.urlshortener.lock
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CustomSpringELParserTest {
+    private val sut = CustomSpringELParser
+
+    @Test
+    fun `sut return argument`() {
+        // Arrange
+        val parameterNames = arrayOf("originUrl")
+        val args = arrayOf<Any>("https://naver.com")
+        val key = "#originUrl"
+        val expected = "https://naver.com"
+
+        // Act
+        val actual = sut.getDynamicValue(parameterNames, args, key)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,21 @@
+spring:
+  application:
+    name: url-shortener
+    data-center-id: 00001
+    server-id: 00001
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MYSQL
+    username: admin
+    password: 0000
+    jpa:
+      open-in-view: false
+      hibernate:
+        ddl-auto: create-drop # tobe validate
+      properties:
+        hibernate:
+          dialect: org.hibernate.dialect.MySQL8Dialect
+          format_sql: true


### PR DESCRIPTION
* 분산환경에서 동시에 같은 origin url이 여러개 등록 시도 될 수 있기 때문에 lock이 필요하다
* 이 방향성에 맞게 origin Url도 같은 url에 대해서는 하나의 short url만 생성할 수 있도록 한다

close: #60