### PR TITLE
Snowflake sign bit 값 0으로 변경

### DIFF
--- a/src/main/kotlin/com/moflow/urlshortener/service/SnowflakeGenerator.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/service/SnowflakeGenerator.kt
@@ -25,6 +25,6 @@ class SnowflakeGenerator(
     companion object {
         private const val RADIX = 2
         private const val SERIAL_NUMBER_REDIS_KEY = "snowflake-serial"
-        private const val SIGN_BIT = "1"
+        private const val SIGN_BIT = "0"
     }
 }

--- a/src/test/kotlin/com/moflow/urlshortener/service/SnowflakeGeneratorTest.kt
+++ b/src/test/kotlin/com/moflow/urlshortener/service/SnowflakeGeneratorTest.kt
@@ -40,7 +40,7 @@ class SnowflakeGeneratorTest(
 
         every { managedCache.increment(any()) } returns serialNumber
         every { snowflakeTimestampGenerator.currentTimestamp() } returns currentTimestamp
-        val expectedKey = "110010100101100111010000010000000000000100011111011"
+        val expectedKey = "010010100101100111010000010000000000000100011111011"
 
         // Act
         val actual = sut.generate()


### PR DESCRIPTION
* sign bit는 뒤의 값이 양수인지 음수인지를 나타내는데 snowflake의 경우는 항상 양수임을 보장하기 위해 0을 사용한다.

close: #68