### PR TITLE
ShortUrlFindService에 cache를 사용하여 부하를 줄인다

### DIFF
--- a/src/main/kotlin/com/moflow/urlshortener/service/ShortUrlFindService.kt
+++ b/src/main/kotlin/com/moflow/urlshortener/service/ShortUrlFindService.kt
@@ -1,17 +1,33 @@
 package com.moflow.urlshortener.service
 
+import com.moflow.urlshortener.cache.ManagedCache
 import com.moflow.urlshortener.dto.ShortUrlDto
 import com.moflow.urlshortener.extension.ShortUrlExtension.toShortUrlDto
 import com.moflow.urlshortener.repository.ShortUrlRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
 
 @Service
 @Transactional(readOnly = true)
 class ShortUrlFindService(
     private val shortUrlRepository: ShortUrlRepository,
+    private val managedCache: ManagedCache,
 ) {
     fun findByOriginUrl(originUrl: String): ShortUrlDto? {
-        return shortUrlRepository.findByOriginUrl(originUrl)?.toShortUrlDto()
+        val redisKey = REDIS_KEY_PREFIX + originUrl
+        managedCache.get<String>(redisKey)?.let {
+            return ShortUrlDto(originUrl = originUrl, shortKey = it)
+        }
+
+        return shortUrlRepository.findByOriginUrl(originUrl)?.let {
+            managedCache.set(redisKey, it.shortKey, REDIS_CACHE_TTL, TimeUnit.DAYS)
+            return it.toShortUrlDto()
+        }
+    }
+
+    companion object {
+        private const val REDIS_KEY_PREFIX = "origin-url:"
+        private const val REDIS_CACHE_TTL = 3L
     }
 }

--- a/src/test/kotlin/com/moflow/urlshortener/service/ShortUrlFindServiceTest.kt
+++ b/src/test/kotlin/com/moflow/urlshortener/service/ShortUrlFindServiceTest.kt
@@ -1,30 +1,38 @@
 package com.moflow.urlshortener.service
 
+import com.moflow.urlshortener.cache.ManagedCache
 import com.moflow.urlshortener.domain.ShortUrl
 import com.moflow.urlshortener.repository.ShortUrlRepository
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.justRun
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.util.concurrent.TimeUnit
 
 @ExtendWith(MockKExtension::class)
 class ShortUrlFindServiceTest(
     @MockK private val shortUrlRepository: ShortUrlRepository,
+    @MockK private val managedCache: ManagedCache,
 ) {
     @InjectMockKs
     private lateinit var sut: ShortUrlFindService
 
     @Test
-    fun `sut should return short url dto when short key is exists`() {
+    fun `sut should return short url dto when short key is exists in rdbms`() {
         // Arrange
         val originUrl = "https://ASDF.com"
         val shortKey = "asdfxC2"
         val shortUrl = ShortUrl(originUrl = originUrl, shortKey = shortKey)
+        val redisKey = "origin-url:$originUrl"
+
+        every { managedCache.get<String>(redisKey) } returns null
         every { shortUrlRepository.findByOriginUrl(originUrl) } returns shortUrl
+        justRun { managedCache.set(redisKey, shortKey, 3L, TimeUnit.DAYS) }
 
         // Act
         val actual = sut.findByOriginUrl(originUrl)
@@ -35,7 +43,36 @@ class ShortUrlFindServiceTest(
             .hasFieldOrPropertyWithValue("shortKey", shortKey)
 
         verify {
+            managedCache.get<String>(redisKey)
             shortUrlRepository.findByOriginUrl(originUrl)
+            managedCache.set(redisKey, shortKey, 3L, TimeUnit.DAYS)
+        }
+    }
+
+    @Test
+    fun `sut should return short url dto when short key is exists in redis`() {
+        // Arrange
+        val originUrl = "https://ASDF.com"
+        val shortKey = "asdfxC2"
+        val redisKey = "origin-url:$originUrl"
+
+        every { managedCache.get<String>(redisKey) } returns shortKey
+
+        // Act
+        val actual = sut.findByOriginUrl(originUrl)
+
+        // Assert
+        assertThat(actual)
+            .hasFieldOrPropertyWithValue("originUrl", originUrl)
+            .hasFieldOrPropertyWithValue("shortKey", shortKey)
+
+        verify {
+            managedCache.get<String>(redisKey)
+        }
+
+        verify(exactly = 0) {
+            shortUrlRepository.findByOriginUrl(originUrl)
+            managedCache.set(redisKey, shortKey, 3L, TimeUnit.DAYS)
         }
     }
 
@@ -43,6 +80,8 @@ class ShortUrlFindServiceTest(
     fun `sut should return null when short key is not exists`() {
         // Arrange
         val originUrl = "https://ASDF.com"
+        val redisKey = "origin-url:$originUrl"
+        every { managedCache.get<String>(redisKey) } returns null
         every { shortUrlRepository.findByOriginUrl(originUrl) } returns null
 
         // Act
@@ -51,7 +90,12 @@ class ShortUrlFindServiceTest(
         // Assert
         assertThat(actual).isNull()
         verify {
+            managedCache.get<String>(redisKey)
             shortUrlRepository.findByOriginUrl(originUrl)
+        }
+
+        verify(exactly = 0) {
+            managedCache.set(redisKey, any(), 3L, TimeUnit.DAYS)
         }
     }
 


### PR DESCRIPTION
* 같은 url에 대해서 맵핑 중복 요청은 최대 3일정도가 소요될것으로 예상하여 Read Through 캐시사용 (행사 등)

close: #73